### PR TITLE
Better support for windows (use any-shell-escape)

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -1,7 +1,7 @@
 var map = require("map-stream");
 var gutil = require("gulp-util");
 var exec = require("child_process").exec;
-var escape = require("shell-escape");
+var escape = require("any-shell-escape");
 
 module.exports = function (opt) {
   if(!opt) opt = {};

--- a/lib/addRemote.js
+++ b/lib/addRemote.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (remote, url, opt, cb) {
   if(!url) cb(new Error('gulp-git: Repo URL is required git.addRemote("origin", "https://github.com/user/repo.git")'));

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (branch, opt, cb) {
   if(!opt) opt = {};

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -1,7 +1,7 @@
 var map = require('map-stream');
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (branch, opt) {
   if(!opt) opt = {};

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -1,7 +1,7 @@
 var map = require('map-stream');
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (message, opt) {
   if(!opt) opt = {};

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (opt, cb) {
   if(!opt) opt = {};

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (branch, opt, cb) {
   if(!opt) opt = {};

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (remote, branch, opt, cb) {
   if(!branch) branch = 'master';

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (remote, branch, opt, cb) {
   if(!branch) branch = 'master';

--- a/lib/rm.js
+++ b/lib/rm.js
@@ -1,7 +1,7 @@
 var map = require('map-stream');
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (opt) {
   if(!opt) opt = {};

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,6 +1,6 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('shell-escape');
+var escape = require('any-shell-escape');
 
 module.exports = function (version, message, opt, cb) {
   if(!version) return cb(new Error('Version must be defined'));

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "gulp-util": "~2.2.14",
     "map-stream": "~0.1.0",
-    "shell-escape": "0.1.0"
+    "any-shell-escape": "0.1.0"
   },
   "devDependencies": {
     "mocha": "*",


### PR DESCRIPTION
Windows just doesn't support the $'foo' escaping that you can use on bash-like shells, so everything fails spectacularly when trying to e.g. add a file to index.

I've [forked](https://github.com/boazy/any-shell-escape) the shell-escape module and tried to make it more generic. It supposed to work on both Windows and bash/zsh now, but still not on every POSIX shell (it doesn't work on csh or dash, for instance).
