### PR TITLE
`git pull` args re-ordering

### DIFF
--- a/lib/pull.js
+++ b/lib/pull.js
@@ -9,7 +9,7 @@ module.exports = function (remote, branch, opt, cb) {
   if(!opt.cwd) opt.cwd = process.cwd();
   if(!opt.args) opt.args = '';
 
-  var cmd = "git pull " + escape([remote, branch])+ " " + opt.args;
+  var cmd = "git pull " + opt.args + " " + escape([remote, branch]);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) gutil.log(err);
     gutil.log(stdout, stderr);


### PR DESCRIPTION
Previous implementation could produce: `git pull origin master --rebase`, which results in an error. `git pull --rebase origin master` is correct.
