### PR TITLE
fix async commit, add/commit use file.base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,10 @@ gulp.task('commit', function(){
 });
 
 // Run git commit with options
-gulp.task('commit', function(){
-  return gulp.src('./git-test/*')
-  .pipe(git.commit('initial commit', {args: '-A --amend -s'}));
+gulp.task('commit', function(done){
+  gulp.src('./git-test/*')
+  .pipe(git.commit('initial commit', {args: '-A --amend -s'}, done));
+  return;
 });
 
 // Run git remote add
@@ -146,7 +147,7 @@ gulp.task('default',['add']);
 
 Options: Object
 
-`.init({args: 'options'})`
+`.init({args: 'options'}, callback)`
 
 Creates an empty git repo
 
@@ -168,13 +169,13 @@ gulp.src: required
 
 Options: Object
 
-`.commit('message', {args: 'options'})`
+`.commit('message', {args: 'options'}, callback)`
 
 Commits changes to repo
 
 `message` allows templates:
 
-`git.commit('initial commit file: <%= file.path%>');`
+`git.commit('initial commit file: <%= file.path%>', {}, callback);`
 
 ### git.addRemote()
 `git remote add <remote> <repo https url>`

--- a/lib/add.js
+++ b/lib/add.js
@@ -8,8 +8,14 @@ module.exports = function (opt) {
   if(!opt.args) opt.args = ' ';
 
   function add(file, cb) {
+    var cwd = '';
+    if (file.stat.isDirectory()) {
+      cwd = file.path;
+    } else {
+      cwd = file.base;
+    }
     var cmd = "git add " + escape([file.path]) + " " + opt.args;
-    exec(cmd, {cwd: file.cwd}, function(err, stdout, stderr){
+    exec(cmd, {cwd: cwd}, function(err, stdout, stderr){
       if(err) gutil.log(err);
       gutil.log(stdout, stderr);
       cb(null, file);

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -3,26 +3,31 @@ var gutil = require('gulp-util');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
-module.exports = function (message, opt) {
+module.exports = function (message, opt, endcb) {
   if(!opt) opt = {};
   if(!message) throw new Error('gulp-git: Commit message is required git.commit("commit message")');
   if(!opt.args) opt.args = ' ';
 
   var files = [];
-  var cwd = '';
 
   var stream = through.obj(function(file, enc, cb){
     this.push(file);
-    files.push(file.path);
-    cwd = file.cwd;
+    if(!opt.cwd) {
+      if (file.stat.isDirectory()) {
+        opt.cwd = file.path;
+      } else {
+        opt.cwd = file.base;
+      }
+    }
     cb();
-  }).on('data', function(){
-
+  }).on('data', function(file){
+    files.push(file.path);
   }).on('end', function(){
     var cmd = 'git commit -m "' + message + '" ' + escape(files) + ' ' + opt.args;
-      exec(cmd, {cwd: cwd}, function(err, stdout, stderr){
-        if(err) gutil.log(err);
-        gutil.log(stdout, stderr);
+    exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
+      if(err) gutil.log(err);
+      gutil.log(stdout, stderr);
+      if(endcb) endcb();
     });
   });
 


### PR DESCRIPTION
As a result of this patch, it's possible to `add()` and `commit()` in repositories other than that of the current working directory.  I'd like to see this behavior everywhere, TBH, but the other calls accept a `{cwd: "..."}` option, so a change is not strictly necessary.

This also allows one to chain `commit()` using the `gulp.task` callback.  It's a hack, but it seemed to be the simplest possible fix and therefore, the easiest with which to explain the problem.

Thanks for gulp-git!
