### PR TITLE
Two git commands made "stream aware": commit & push

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -40,7 +40,7 @@ module.exports = function (message, opt) {
     });
     git.on('exit', function(code) {
       if(code) {
-        gutil.log('git-commit: exit: ' + gutil.colors.purple(code) );
+        gutil.log('git-commit: exit: ' + gutil.colors.magenta(code) );
         return cb('git-commit: exit: ' + code);
       }
       gutil.log('git-commit: ' + gutil.colors.green('Done.') );

--- a/lib/push.js
+++ b/lib/push.js
@@ -38,7 +38,7 @@ module.exports = function (remote, branch, opt, cb) {
     });
     git.on('exit', function(code) {
       if(code) {
-        gutil.log('git-push: exit: ' + gutil.colors.purple(code) );
+        gutil.log('git-push: exit: ' + gutil.colors.magenta(code) );
         return cb('git-push: exit: ' + code);
       }
       gutil.log('git-push: ' + gutil.colors.green('Done.') );


### PR DESCRIPTION
This PR is submitted for discussion and aims to address [#14](https://github.com/stevelacy/gulp-git/issues/14). It is NOT complete or ready for merging.

Here are the highlights:
- By using `spawn` instead of `exec`, the command output can be streamed instead of buffered. Very useful when watching a push to Heroku or similar.
- By using the second param of `through.obj()` with a callback, execution does not advance to the next stage of the pipeline until the command returns.

The result is that `add`, `commit`, and `push` can all be chained in a single task.

Example:

``` javascript
  var cwd = "" + process.cwd() + "/dist/" + target;
  gulp.src('./', {cwd: cwd, read: false})
    .pipe( git.add({args: '--all'}) )
    .pipe( git.commit("Deploy: " + target) )
    .on('error', gutil.beep)
    .pipe( git.push('dokku.dev', 'master', {cwd: cwd}) )
    .on('error', gutil.beep);
```
