### PR TITLE
Supply default cb value

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -3,6 +3,7 @@ var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
 module.exports = function (version, message, opt, cb) {
+  if(!cb) { cb = function (err) { if (err) throw err; } }
   if(!version) return cb(new Error('Version must be defined'));
   if(!message) return cb(new Error('Message must be defined'));
   if(!opt) opt = {};


### PR DESCRIPTION
I got this strange messages from gulp-git tag function:

```
/Users/floatdrop/sketchboard/node_modules/gulp-git/lib/tag.js:17
    if(err) cb(err);
            ^
TypeError: undefined is not a function
    at /Users/floatdrop/sketchboard/node_modules/gulp-git/lib/tag.js:17:13
```

Instead of this:

```
/Users/floatdrop/sketchboard/node_modules/gulp-git/lib/tag.js:6
  if(!cb) { cb = function (err) { if (err) throw err; } }
                                                 ^
Error: Command failed: fatal: tag 'v0.0.1' already exists
```

I'm using gulp-git to tag and publish code like this:

``` js
    git.commit(message, { args: '-a' }).end();
    git.tag(v, message);
    git.push('origin', 'master', '--tags');    
```
