### PR TITLE
Make git.add() aware of opt.cwd

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -8,7 +8,7 @@ module.exports = function (opt) {
   if(!opt.args) opt.args = ' ';
 
   function add(file, cb) {
-    var cwd = opt.cwd || fileCwd;
+    var cwd = opt.cwd || file.cwd;
 
     var cmd = "git add " + escape([file.path]) + " " + opt.args;
     exec(cmd, {cwd: cwd}, function(err, stdout, stderr){


### PR DESCRIPTION
This pull request allows git.add() to take in cwd, in the same style as other commands. This allows the workflow of automating updating repositories outside the cwd - for instance, automating bower package publishing (what I'm using it for).
