### PR TITLE
Enable git.add() and git.rm() to handle multiple files without getting a lock.

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -1,4 +1,4 @@
-var map = require("map-stream");
+var through = require('through2');
 var gutil = require("gulp-util");
 var exec = require("child_process").exec;
 var escape = require("any-shell-escape");
@@ -7,17 +7,28 @@ module.exports = function (opt) {
   if(!opt) opt = {};
   if(!opt.args) opt.args = ' ';
 
-  function add(file, cb) {
-    var cwd = opt.cwd || file.cwd;
+  var paths = [];
+  var files = [];
+  var fileCwd = process.cwd;
+  var write = function(file, enc, cb) {
+    paths.push(file.path);
+    files.push(file);
+    fileCwd = file.cwd;
+    cb();
+  }
 
-    var cmd = "git add " + escape([file.path]) + " " + opt.args;
+  var flush = function(cb) {
+    var cwd = opt.cwd || fileCwd;
+
+    var cmd = "git add " + escape(paths) + " " + opt.args;
+    var that = this;
     exec(cmd, {cwd: cwd}, function(err, stdout, stderr){
       if(err) cb(err);
       gutil.log(stdout, stderr);
-      cb(null, file);
+      files.forEach(that.push.bind(that));
+      cb();
     });
   }
 
-  // Return a stream
-  return map(add);
+  return through.obj(write, flush);
 };

--- a/lib/rm.js
+++ b/lib/rm.js
@@ -1,4 +1,4 @@
-var map = require('map-stream');
+var through = require('through2');
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
@@ -6,18 +6,29 @@ var escape = require('any-shell-escape');
 module.exports = function (opt) {
   if(!opt) opt = {};
   if(!opt.args) opt.args = ' ';
-  
-  function rm(file, cb) {
-    console.log(file.path);
-    if(!file.path) throw new Error('gulp-git: file is required');
-    var cmd = "git rm " + escape([file.path]) + " " + opt.args;
-    exec(cmd, {cwd: file.cwd}, function(err, stdout, stderr){
+
+  var paths = [];
+  var files = [];
+  var fileCwd = process.cwd;
+  var write = function(file, enc, cb) {
+    paths.push(file.path);
+    files.push(file);
+    fileCwd = file.cwd;
+    cb();
+  }
+
+  var flush = function(cb) {
+    var cwd = opt.cwd || fileCwd;
+
+    var cmd = "git rm " + escape(paths) + " " + opt.args;
+    var that = this;
+    exec(cmd, {cwd: cwd}, function(err, stdout, stderr){
       if(err) cb(err);
       gutil.log(stdout, stderr);
-      cb(null, file);
+      files.forEach(that.push.bind(that));
+      cb();
     });
   }
 
-  // Return a stream
-  return map(rm);
+  return through.obj(write, flush);
 };


### PR DESCRIPTION
I rewrote the add() and rm() functionality so that, when adding (or rm-ing) multiple files from a pipe, the repository is not locked halfway through and only half work is done. The code is inspired by how commit() is implemented.

I also added two unit test for them, which both succeed (at least on my machine :) )
