### PR TITLE
Updated version dependency of gulp-util to resolve installing with Gulp ...

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
   "main": "./index.js",
   "dependencies": {
     "any-shell-escape": "^0.1.1",
-    "gulp-util": "~2.2.14",
+    "gulp-util": "~3.0.1",
     "require-dir": "^0.1.0",
     "through2": "^0.4.1"
   },


### PR DESCRIPTION
When I attempted to install this package with Gulp 3 I received the following error:

```
npm ERR! Error: EACCES, mkdir '/Users/me/.npm/gulp-util/2.2.20'
npm ERR!  { [Error: EACCES, mkdir '/Users/me/.npm/gulp-util/2.2.20']
npm ERR!   errno: 3,
npm ERR!   code: 'EACCES',
npm ERR!   path: '/Users/me/.npm/gulp-util/2.2.20',
npm ERR!   parent: 'gulp-git' }
```

To resolve this issue I updated the version of the gulp-util dependency to 3.0.1.  This seems to have resolved the issue for me.
