### PR TITLE
Add a setRemote function

### DIFF
--- a/lib/addRemote.js
+++ b/lib/addRemote.js
@@ -1,6 +1,5 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('any-shell-escape');
 
 module.exports = function (remote, url, opt, cb) {
   if (!cb && typeof opt === 'function') {
@@ -14,7 +13,7 @@ module.exports = function (remote, url, opt, cb) {
   if(!opt.cwd) opt.cwd = process.cwd();
   if(!opt.args) opt.args = ' ';
 
-  var cmd = "git remote add " + opt.args + " " + escape([remote, url]);
+  var cmd = "git remote add " + opt.args + " " + remote + " " + url;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) cb(err);
     gutil.log(stdout, stderr);

--- a/lib/setRemote.js
+++ b/lib/setRemote.js
@@ -1,0 +1,22 @@
+var gutil = require('gulp-util');
+var exec = require('child_process').exec;
+var escape = require('any-shell-escape');
+
+module.exports = function (remote, url, opt, cb) {
+  if(!cb && typeof opt === 'function') {
+    cb = opt;
+    opt = {};
+  }
+  if(!url) cb(new Error('gulp-git: Repo URL is required git.setRemote("origin", "https://github.com/user/repo.git")'));
+  if(!remote) remote = 'origin';
+  if(!opt) opt = {};
+  if(!opt.cwd) opt.cwd = process.cwd();
+  if(!opt.args) opt.args = ' ';
+
+  var cmd = "git remote set-url " + opt.args + " " + escape([remote, url]);
+  return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
+    if(err) cb(err);
+    gutil.log(stdout, stderr);
+    cb();
+  });
+};

--- a/lib/setRemote.js
+++ b/lib/setRemote.js
@@ -1,6 +1,5 @@
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
-var escape = require('any-shell-escape');
 
 module.exports = function (remote, url, opt, cb) {
   if(!cb && typeof opt === 'function') {
@@ -13,7 +12,7 @@ module.exports = function (remote, url, opt, cb) {
   if(!opt.cwd) opt.cwd = process.cwd();
   if(!opt.args) opt.args = ' ';
 
-  var cmd = "git remote set-url " + opt.args + " " + escape([remote, url]);
+  var cmd = "git remote set-url " + opt.args + " " + remote + " " + url;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) cb(err);
     gutil.log(stdout, stderr);


### PR DESCRIPTION
This takes care of #56 for me.

I ran into issues with [any-shell-escape](https://www.npmjs.org/package/any-shell-escape) in this case, and ended up having to remove it for it to work as intended. Same with `addRemote()`.

First, I was getting a "has no method 'Replace'" error returned. It wasn't passing the value as a string, which was easy to get around using `.join()`.. But then, obviously, that brought out issues with the executed git command having quotes where they shouldn't be, etc.

Removing it has worked for me. This PR also removes it from `addRemote`.