### PR TITLE
Add support for gulp-data

### DIFF
--- a/lib/checkoutFiles.js
+++ b/lib/checkoutFiles.js
@@ -2,12 +2,15 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
+var _ = require('lodash');
 
 module.exports = function (opt) {
   if(!opt) opt = {};
-  if(!opt.args) opt.args = ' ';
 
   function checkout(file, enc, cb) {
+    if(file.data) opt = _.extend(opt, file.data);
+    if(!opt.args) opt.args = ' ';
+    
     var that = this;
     var cmd = "git checkout " + opt.args + " " + escape([file.path]);
     exec(cmd, {cwd: file.cwd}, function(err, stdout, stderr){

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -3,33 +3,36 @@ var gutil = require('gulp-util');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 var path = require('path');
+var _ = require('lodash');
 
 // want to get the current git hash instead?
 // git.revParse({args:'--short HEAD'})
 
 module.exports = function(message, opt) {
+  if(typeof message === 'object') opt = message;
   if(!opt) opt = {};
-  if(!message || message.length === 0) {
-    if (opt.args.indexOf('--amend') === -1) {
-      throw new Error('gulp-git: Commit message is required git.commit("commit message") or --amend arg must be given');
-    }
-  }
   if(!opt.cwd) opt.cwd = process.cwd();
   if(!opt.args) opt.args = ' ';
-
+  if(typeof message === 'string') opt.message = message;
+  
   var files = [];
   var paths = [];
 
   var write = function(file, enc, cb){
+    if(file.data) opt = _.extend(opt, file.data);
+    
     files.push(file);
     paths.push(path.relative(opt.cwd, file.path).replace('\\','/'));
     cb();
   };
 
   var flush = function(cb){
+    if(!opt.message && opt.args.indexOf('--amend') === -1)
+      throw new Error('gulp-git: Commit message is required git.commit("commit message") or --amend arg must be given');
+    
     var cmd = 'git commit ';
-    if (message && opt.args.indexOf('--amend') === -1) {
-      cmd += '-m "' + message + '" ' + opt.args + ' ' + escape(paths);
+    if (opt.message && opt.args.indexOf('--amend') === -1) {
+      cmd += '-m "' + opt.message + '" ' + opt.args + ' ' + escape(paths);
 
     } else {
       // When amending, just add the file automatically and do not include the message not the file.

--- a/lib/rm.js
+++ b/lib/rm.js
@@ -2,15 +2,18 @@ var through = require('through2');
 var gutil = require('gulp-util');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
+var _ = require('lodash');
 
 module.exports = function (opt) {
   if(!opt) opt = {};
-  if(!opt.args) opt.args = ' ';
 
   var paths = [];
   var files = [];
   var fileCwd = process.cwd;
   var write = function(file, enc, cb) {
+    if(file.data) opt = _.extend(opt, file.data);
+    if(!opt.args) opt.args = ' ';
+    
     paths.push(file.path);
     files.push(file);
     fileCwd = file.cwd;

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "any-shell-escape": "^0.1.1",
     "gulp-util": "^3.0.1",
+    "lodash": "^2.4.1",
     "require-dir": "^0.1.0",
     "through2": "^0.6.3"
   },

--- a/test/commit.js
+++ b/test/commit.js
@@ -23,5 +23,39 @@ module.exports = function(git, util){
     gitS.write(fakeFile);
     gitS.end();
   });
+  
+  it('should accept a commit message via file.data', function(done) {
+    var fakeFile = util.testFiles[1];
+    fakeFile.data = {message: 'initial commit'};
+    var opt = {cwd: './test/repo/'};
+    var gitS = git.commit(opt);
+    gitS.once('finish', function(){
+      setTimeout(function(){
+        fs.readFileSync(util.testCommit)
+          .toString('utf8')
+          .should.match(/initial commit/);
+        done();
+      }, 100);
+    });
+    gitS.write(fakeFile);
+    gitS.end();
+  });
+  
+  
+  it('should accept all options via file.data', function(done) {
+    var fakeFile = util.testFiles[2];
+    fakeFile.data = {message: 'initial commit', cwd: './test/repo/'};
+    var gitS = git.commit();
+    gitS.once('finish', function(){
+      setTimeout(function(){
+        fs.readFileSync(util.testCommit)
+          .toString('utf8')
+          .should.match(/initial commit/);
+        done();
+      }, 100);
+    });
+    gitS.write(fakeFile);
+    gitS.end();
+  });
 
 };

--- a/test/rm.js
+++ b/test/rm.js
@@ -23,10 +23,26 @@ module.exports = function(git, util){
     gitS.write(fakeFile);
     gitS.end();
   });
+  
+  it('should accept options via file.data', function(done) {
+    var fakeFile = new gutil.File(util.testFiles[1]);
+    fakeFile.data = {args: '-f', cwd: 'test/repo'};
+    var gitS = git.rm();
+    gitS.once('data', function (newFile) {
+      setTimeout(function(){
+        fs.exists('test/repo/'+newFile, function(exists) {
+          exists.should.be.false;
+        });
+        done();
+      }, 100);
+    });
+    gitS.write(fakeFile);
+    gitS.end();
+  });
 
   it('should rm multiple files', function(done) {
     var fakeFiles = [];
-    util.testFiles.slice(1).forEach(function(file){
+    util.testFiles.slice(2).forEach(function(file){
       fakeFiles.push(new gutil.File(file));
     });
 


### PR DESCRIPTION
It would be handy to be able to pipe in options, such as commit messages, using [gulp-data](https://www.npmjs.com/package/gulp-data).

This would permit the following task for tagging versions:

```js
var gulp = require('gulp');
var bump = require('gulp-bump');
var git = require('gulp-git');
var data = require('gulp-data');

gulp.task('tag', function () {
  var version;
  
  //pipe the package.json through gulp-bump and save it
  return gulp.src('./package.json')
    .pipe(bump())
    .pipe(gulp.dest('./'))
    .pipe(data(function (file) {
      //parse the package.json and get the version number
      version = JSON.parse(file.contents.toString()).version;
      //construct the commit message from the version number
      return {message: 'Version ' + version};
    }))
    //git.commit will get the commit message from the gulp-data function above
    .pipe(git.commit())
    .on('end', function () {
      //tag the new version
      git.tag('v' + version, 'Version ' + version, function (err) {
        if (err) throw err;
      });
    });
});
```

Thanks!