### PR TITLE
Add `quiet` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ gulp.task('default',['add']);
 
 Creates an empty git repo
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -223,7 +223,7 @@ Clones a remote repo for the first time
 
 `remote`: String, remote url
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -238,7 +238,7 @@ git.clone('https://remote.git', function (err) {
 
 Adds files to repo
 
-`opt`: Object (optional) `{args: 'options'}`
+`opt`: Object (optional) `{args: 'options', quiet: true}`
 
 ```js
 gulp.src('./*')
@@ -253,7 +253,7 @@ Commits changes to repo
 
 `message`: String, commit message
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 ```js
 gulp.src('./*')
@@ -270,7 +270,7 @@ Adds remote repo url
 
 `url`: String, url of remote
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -289,7 +289,7 @@ Pulls changes from remote repo
 
 `branch`: String, branch, default: `master`
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -308,7 +308,7 @@ Pushes changes to remote repo
 
 `branch`: String, branch, default: `master`
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -327,7 +327,7 @@ Tags repo with release version
 
 `message`: String, tag message
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -349,7 +349,7 @@ Creates a new branch but doesn't switch to it
 
 `branch`: String, branch
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -366,7 +366,7 @@ Checkout a new branch with files
 
 `branch`: String, branch
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -396,7 +396,7 @@ gulp.src('./*')
 
 Checkout (e.g. reset) files
 
-`opt`: Object (optional) `{args: 'options'}`
+`opt`: Object (optional) `{args: 'options', quiet: true}`
 
 ```js
 gulp.src('./*')
@@ -410,7 +410,7 @@ Merges a branch into the current branch
 
 `branch`: String, source branch
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -425,7 +425,7 @@ git.merge('development', function (err) {
 
 Removes a file from git and deletes it
 
-`opt`: Object (optional) `{args: 'options'}`
+`opt`: Object (optional) `{args: 'options', quiet: true}`
 
 ```js
 gulp.src('./*')
@@ -440,7 +440,7 @@ Resets working directory to specified commit hash
 
 `commit`: String, commit hash or reference
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any
 
@@ -455,7 +455,7 @@ git.reset('HEAD' {args:'--hard'}, function (err) {
 
 Get details about the repository
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function, passed err if any and command stdout
 
@@ -472,14 +472,14 @@ git.revParse({args:'--short HEAD'}, function (err, hash) {
 
 Options: Object
 
-`.addSubmodule('https://repository.git', 'path', {args: "options"})`
+`.addSubmodule('https://repository.git', 'path', {args: "options", quiet: true})`
 
 ### git.updateSubmodule()
 `git submodule update <options>`
 
 Options: Object
 
-`.updateSubmodule({args: "options"})`
+`.updateSubmodule({args: "options", quiet: true})`
 
 
 ### git.status(opt, cb)
@@ -487,7 +487,7 @@ Options: Object
 
 Show the working tree status
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function (optional), passed err and command stdout
 
@@ -502,7 +502,7 @@ git.status({args : '--porcelain'}, function (err, stdout) {
 
 Run other git actions that do not require a Vinyl.
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path'}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 
 `cb`: function (optional), passed err and command stdout
 

--- a/lib/add.js
+++ b/lib/add.js
@@ -25,7 +25,7 @@ module.exports = function (opt) {
     var that = this;
     exec(cmd, {cwd: cwd}, function(err, stdout, stderr){
       if(err) cb(err);
-      gutil.log(stdout, stderr);
+      if(!opt.quiet) gutil.log(stdout, stderr);
       files.forEach(that.push.bind(that));
       cb();
     });

--- a/lib/addRemote.js
+++ b/lib/addRemote.js
@@ -17,7 +17,7 @@ module.exports = function (remote, url, opt, cb) {
   var cmd = "git remote add " + opt.args + " " + escape([remote, url]);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/addSubmodule.js
+++ b/lib/addSubmodule.js
@@ -11,7 +11,7 @@ module.exports = function (url, name, opt, cb) {
     var cmd = "git submodule add " + opt.args + " " + url + " " + name;
     return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
       if(err && cb) cb(err);
-      gutil.log(stdout, stderr);
+      if(!opt.quiet) gutil.log(stdout, stderr);
       if(cb) cb();
     });
 };

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -19,7 +19,7 @@ module.exports = function (branch, opt, cb) {
   var cmd = "git branch " + opt.args + " " + escape([branch]);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -16,7 +16,7 @@ module.exports = function (branch, opt, cb) {
   var cmd = "git checkout " + opt.args + " " + escape([branch]);
   exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb(null);
   });
 };

--- a/lib/checkoutFiles.js
+++ b/lib/checkoutFiles.js
@@ -12,7 +12,7 @@ module.exports = function (opt) {
     var cmd = "git checkout " + opt.args + " " + escape([file.path]);
     exec(cmd, {cwd: file.cwd}, function(err, stdout, stderr){
       if(err) return cb(err);
-      gutil.log(stdout, stderr);
+      if(!opt.quiet) gutil.log(stdout, stderr);
       that.push(file);
       cb(null);
     });

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -15,7 +15,7 @@ module.exports = function (remote, opt, cb) {
   var cmd = "git clone " + escape([remote]) + " " + opt.args;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -39,7 +39,7 @@ module.exports = function(message, opt) {
     var self = this;
     exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
       if(err) return cb(err);
-      gutil.log(stdout, stderr);
+      if(!opt.quiet) gutil.log(stdout, stderr);
       files.forEach(self.push.bind(self));
       if(cb) cb();
     });

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -15,8 +15,10 @@ module.exports = function (opt, cb) {
   var cmd = "git " + opt.args;
   return exec(cmd, {cwd : opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err, stderr);
-    if(opt.log) gutil.log(cmd + '\n' + stdout, stderr);
-    else gutil.log(cmd + ' (log : false)', stderr);
+    if(opt.log && !opt.quiet) gutil.log(cmd + '\n' + stdout, stderr);
+    else {
+      if(!opt.quiet) gutil.log(cmd + ' (log : false)', stderr);
+    }
     cb(err, stdout);
   });
 };

--- a/lib/init.js
+++ b/lib/init.js
@@ -14,7 +14,7 @@ module.exports = function (opt, cb) {
   var cmd = "git init " + opt.args;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -16,7 +16,7 @@ module.exports = function (branch, opt, cb) {
   var cmd = "git merge " + opt.args + " " + escape([branch]);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -17,7 +17,7 @@ module.exports = function (remote, branch, opt, cb) {
   var cmd = "git pull " + opt.args + " " + escape([remote, branch]);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/push.js
+++ b/lib/push.js
@@ -18,7 +18,7 @@ module.exports = function (remote, branch, opt, cb) {
   var cmd = "git push " + escape([remote, branch]) + " " + opt.args;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -16,7 +16,7 @@ module.exports = function (commit, opt, cb) {
   var cmd = "git reset " + opt.args + " " + escape([commit]);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 

--- a/lib/revParse.js
+++ b/lib/revParse.js
@@ -24,7 +24,7 @@ module.exports = function (opt, cb) {
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if (err) return cb(err);
     if (stdout) stdout = stdout.trim(); // Trim trailing cr-lf
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb(err, stdout); // return stdout to the user
   });
 };

--- a/lib/rm.js
+++ b/lib/rm.js
@@ -24,7 +24,7 @@ module.exports = function (opt) {
     var that = this;
     exec(cmd, {cwd: cwd}, function(err, stdout, stderr){
       if(err) cb(err);
-      gutil.log(stdout, stderr);
+      if(!opt.quiet) gutil.log(stdout, stderr);
       files.forEach(that.push.bind(that));
       cb();
     });

--- a/lib/status.js
+++ b/lib/status.js
@@ -14,7 +14,7 @@ module.exports = function (opt, cb) {
   var cmd = "git status " + opt.args;
   return exec(cmd, {cwd : opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err, stderr);
-    gutil.log(cmd + '\n' + stdout, stderr);
+    if(!opt.quiet) gutil.log(cmd + '\n' + stdout, stderr);
     if(cb) cb(err, stdout);
   });
 };

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -20,7 +20,7 @@ module.exports = function (version, message, opt, cb) {
   var templ = gutil.template(cmd, {file:message});
   return exec(templ, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err) return cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     cb();
   });
 };

--- a/lib/updateSubmodule.js
+++ b/lib/updateSubmodule.js
@@ -9,7 +9,7 @@ module.exports = function(opt, cb){
   var cmd = "git submodule update " + opt.args;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if(err && cb) cb(err);
-    gutil.log(stdout, stderr);
+    if(!opt.quiet) gutil.log(stdout, stderr);
     if(cb) cb();
   });
 };


### PR DESCRIPTION
Add a `quiet` option to every function, preventing output on `gutil.log`.