### PR TITLE
break up multiline comment messages

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -28,11 +28,30 @@ module.exports = function(message, opt) {
     cb();
   };
 
+  var messageEntry = function(entry) {
+    return '-m "' + entry + '" ';
+  };
+
   var flush = function(cb){
     var cmd = 'git commit ';
-    if (message && opt.args.indexOf('--amend') === -1) {
-      cmd += '-m "' + message + '" ' + opt.args + ' ' + escape(paths);
 
+    if (message && opt.args.indexOf('--amend') === -1) {
+
+      // Check if the message is multiline
+      if (message && message.split('\n').length > 0) {
+
+        var lines = message.split('\n');
+        var numLines = lines.length;
+        var messageExpanded = '';
+
+        // repeat -m as needed
+        for (var i = 0; i < numLines; i++) {
+          messageExpanded += messageEntry(lines[i]);
+        }
+        cmd += messageExpanded + opt.args + ' ' + escape(paths);        
+      } else {
+        cmd += message + opt.args + ' ' + escape(paths);
+      }
     } else {
       // When amending, just add the file automatically and do not include the message not the file.
       // Also, add all the files and avoid lauching the editor (even if --no-editor was added)


### PR DESCRIPTION
As the [git docs mention](http://git-scm.com/docs/git-commit), if multiple -m options are given to `git commit`, their values are concatenated as separate paragraphs (lines). Since javascript now supports multiple line string literal templates in ES6, we should convert multi line string literals to unique -m entries when working with git's cli.