### PR TITLE
Adds disableMessageRequirement option

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,15 @@ gulp.task('commit', function(){
     .pipe(git.commit('initial commit', {args: '-A --amend -s'}));
 });
 
+// Run git commit without checking for a message using raw arguments
+gulp.task('commit', function(){
+  return gulp.src('./git-test/*')
+    .pipe(git.commit(undefined, { 
+      args: '-m "initial commit"',
+      disableMessageRequirement: true
+    }));
+});
+
 // Run git remote add
 // remote is the remote repo
 // repo is the https url of the repo
@@ -268,7 +277,7 @@ Commits changes to repo
 
 `message`: String, commit message
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true, disableMessageRequirement: false}`
 
 ```js
 gulp.src('./*')

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -31,6 +31,14 @@ gulp.task('commitopts', function(){
   .pipe(git.commit('initial commit', {args: '-v'}));
 });
 
+// Commit files using raw arguments, without message checking
+gulp.task('commitraw', function(){
+  gulp.src('./*')
+  .pipe(git.commit(undefined, { 
+    args: '-m "initial commit"',
+    disableMessageRequirement: true
+  }));
+});
 
 // Add remote
 

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -52,6 +52,8 @@ module.exports = function(message, opt) {
       } else {
         cmd += message + opt.args + ' ' + escape(paths);
       }
+    } else if (opt.disableMessageRequirement === true) {
+      cmd += opt.args;
     } else {
       // When amending, just add the file automatically and do not include the message not the file.
       // Also, add all the files and avoid lauching the editor (even if --no-editor was added)

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -12,7 +12,7 @@ var path = require('path');
 module.exports = function(message, opt) {
   if (!opt) opt = {};
   if (!message || message.length === 0) {
-    if (opt.args.indexOf('--amend') === -1) {
+    if (opt.args.indexOf('--amend') === -1 && opt.disableMessageRequirement !== true) {
       throw new Error('gulp-git: Commit message is required git.commit("commit message") or --amend arg must be given');
     }
   }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "gulp-git",
   "description": "Git plugin for gulp (gulpjs.com)",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "homepage": "http://github.com/stevelacy/gulp-git",
   "repository": {
     "type": "git",

--- a/test/commit.js
+++ b/test/commit.js
@@ -37,4 +37,20 @@ module.exports = function(git, util){
     gitS.end();
   });
 
+  it('should commit a file to the repo using raw arguments only', function(done) {
+    var fakeFile = util.testFiles[3];
+    var opt = {cwd: './test/repo/', args:'-m "initial commit"', disableMessageRequirement: true};
+    var gitS = git.commit(undefined, opt);
+    gitS.once('finish', function(){
+      setTimeout(function(){
+        fs.readFileSync(util.testCommit)
+          .toString('utf8')
+          .should.match(/initial commit/);
+        done();
+      }, 100);
+    });
+    gitS.write(fakeFile);
+    gitS.end();
+  });
+
 };


### PR DESCRIPTION
I have a use case which requires me to pass a raw argument string to git commit. A user will set the message in this raw string. Setting disableMessageRequirement to true will allow libraries to disable the sensible defaults in special cases.