### PR TITLE
Adds disableAppendPaths option to git.commit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,15 @@ gulp.task('commit', function(){
     }));
 });
 
+// Run git commit without appending a path to the commits
+gulp.task('commit', function(){
+  return gulp.src('./git-test/*')
+    .pipe(git.commit('initial commit', {
+      disableAppendPaths: true
+    }));
+});
+
+
 // Run git remote add
 // remote is the remote repo
 // repo is the https url of the repo
@@ -277,7 +286,7 @@ Commits changes to repo
 
 `message`: String, commit message
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true, disableMessageRequirement: false}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true, disableMessageRequirement: false, disableAppendPaths: false}`
 
 ```js
 gulp.src('./*')

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -48,9 +48,15 @@ module.exports = function(message, opt) {
         for (var i = 0; i < numLines; i++) {
           messageExpanded += messageEntry(lines[i]);
         }
-        cmd += messageExpanded + opt.args + ' ' + escape(paths);        
+        cmd += messageExpanded + opt.args; 
+        if(!opt.disableAppendPaths) {
+          cmd += ' ' + escape(paths); 
+        }
       } else {
-        cmd += message + opt.args + ' ' + escape(paths);
+        cmd += message + opt.args;
+        if(!opt.disableAppendPaths) {
+          cmd += ' ' + escape(paths); 
+        }
       }
     } else if (opt.disableMessageRequirement === true) {
       cmd += opt.args;

--- a/test/_util.js
+++ b/test/_util.js
@@ -35,12 +35,27 @@ var testFiles = (function(){
   return testFiles;
 }).call(this);
 
+var testOptionsFiles = (function(){
+  var testFiles = [];
+  for (var i = 0; i < 10; i++) {
+    testFiles[i] = {
+      base: 'test/repo',
+      cwd: 'test/repo',
+      path: __dirname + '/repo/test.options.' + i + '.js',
+      contents: new Buffer(fileContents())
+    };
+    fs.openSync(testFiles[i].path, 'w');
+  }
+  return testFiles;
+}).call(this);
+
 
 module.exports = {
   repo: repo,
   fileContents: fileContents(),
   testCommit: path.join(repo, '.git', 'COMMIT_EDITMSG'),
   testFiles: testFiles,
+  testOptionsFiles: testOptionsFiles,
   testSuite: function(){
     var testSuite = fs.readdirSync(__dirname);
     var testFirst = [

--- a/test/commit.js
+++ b/test/commit.js
@@ -5,6 +5,7 @@ var path = require('path');
 var rimraf = require('rimraf');
 var should = require('should');
 var gutil = require('gulp-util');
+var exec = require('child_process').exec;
 
 module.exports = function(git, util){
 
@@ -53,4 +54,23 @@ module.exports = function(git, util){
     gitS.end();
   });
 
+  it('should commit a file to the repo when appending paths is disabled', function(done) {
+    var fakeFile = util.testOptionsFiles[4];
+    exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
+      function (error, stdout, stderr) {
+        var opt = {cwd: './test/repo/', disableAppendPaths: true};
+        var gitS = git.commit('initial commit', opt);
+        gitS.on('end', function(err) {
+          if(err) {console.error(err); }
+          setTimeout(function(){
+            fs.readFileSync(util.testCommit)
+              .toString('utf8')
+              .should.match(/initial commit/);
+            done();
+          }, 100);
+        });
+        gitS.write(fakeFile);
+        gitS.end();
+    });
+  });
 };


### PR DESCRIPTION
This option is useful in specific cases where you might want to call commit, but not want to have any paths added to the end of the commit string. Specifically, if you're providing it via raw arguments, manually, instead.

Tests, docs included.