### PR TITLE
Add 'maxBuffer' option

### DIFF
--- a/README.md
+++ b/README.md
@@ -286,7 +286,7 @@ Commits changes to repo
 
 `message`: String, commit message
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true, disableMessageRequirement: false, disableAppendPaths: false}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', maxBuffer: 200 * 1024, quiet: true, disableMessageRequirement: false, disableAppendPaths: false}`
 
 ```js
 gulp.src('./*')
@@ -539,7 +539,7 @@ Options: Object
 
 Show the working tree status
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', maxBuffer: 200 * 1024, quiet: true}`
 
 `cb`: function (optional), passed err and command stdout
 

--- a/README.md
+++ b/README.md
@@ -554,7 +554,7 @@ git.status({args : '--porcelain'}, function (err, stdout) {
 
 Run other git actions that do not require a Vinyl.
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', maxBuffer: 200 * 1024, quiet: true}`
 
 `cb`: function (optional), passed err and command stdout
 

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -17,6 +17,7 @@ module.exports = function(message, opt) {
     }
   }
   if (!opt.cwd) opt.cwd = process.cwd();
+  if (!opt.maxBuffer) opt.maxBuffer = 200 * 1024; //Default buffer value for child_process.exec
   if (!opt.args) opt.args = ' ';
 
   var files = [];
@@ -66,7 +67,7 @@ module.exports = function(message, opt) {
       cmd += '-a ' + opt.args + (opt.args.indexOf('--no-edit') === -1 ? ' --no-edit' : '');
     }
     var self = this;
-    exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
+    exec(cmd, {cwd: opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr){
       if (err) return cb(err);
       if (!opt.quiet) gutil.log(stdout, stderr);
       files.forEach(self.push.bind(self));

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -13,10 +13,12 @@ module.exports = function (opt, cb) {
   if (!opt) opt = { };
   if (!opt.log) opt.log = !cb;
   if (!opt.cwd) opt.cwd = process.cwd();
+  if (!opt.maxBuffer) opt.maxBuffer = 200 * 1024; //Default buffer value for child_process.exec
+
   if (!opt.args) opt.args = ' ';
 
   var cmd = 'git ' + opt.args;
-  return exec(cmd, {cwd : opt.cwd}, function(err, stdout, stderr){
+  return exec(cmd, {cwd : opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr){
     if (err) return cb(err, stderr);
     if (opt.log && !opt.quiet) gutil.log(cmd + '\n' + stdout, stderr);
     else {

--- a/lib/status.js
+++ b/lib/status.js
@@ -12,10 +12,11 @@ module.exports = function (opt, cb) {
   if (!cb || typeof cb !== 'function') cb = function () {};
   if (!opt) opt = {};
   if (!opt.cwd) opt.cwd = process.cwd();
+  if (!opt.maxBuffer) opt.maxBuffer = 200 * 1024; //Default buffer value for child_process.exec
   if (!opt.args) opt.args = ' ';
 
   var cmd = 'git status ' + opt.args;
-  return exec(cmd, {cwd : opt.cwd}, function(err, stdout, stderr){
+  return exec(cmd, {cwd : opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr){
     if (err) return cb(err, stderr);
     if (!opt.quiet) gutil.log(cmd + '\n' + stdout, stderr);
     if (cb) cb(err, stdout);


### PR DESCRIPTION
Add `maxBuffer` option to `git.commit` and `git.status` commands.
This option is directly bound to the same option of the `child_process.exec` command.
Also update *README* as well.