### PR TITLE
Edit multiple line commit message functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,12 @@ gulp.task('commit', function(){
     }));
 });
 
+// Run git commit, passing multiple messages as if calling
+// git commit -m "initial commit" -m "additional message"
+gulp.task('commit', function(){
+  return gulp.src('./git-test/*')
+    .pipe(git.commit(['initial commit', 'additional message']));
+});
 
 // Run git remote add
 // remote is the remote repo

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -40,6 +40,12 @@ gulp.task('commitraw', function(){
   }));
 });
 
+// Commit files using raw arguments, without message checking
+gulp.task('commitmulti', function(){
+  gulp.src('./*')
+  .pipe(git.commit(['initial commit', 'additional message']));
+});
+
 // Add remote
 
 gulp.task('remote', function(){

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -38,22 +38,20 @@ module.exports = function(message, opt) {
     if (message && opt.args.indexOf('--amend') === -1) {
 
       // Check if the message is multiline
-      if (message && message.split('\n').length > 0) {
+      if (message && message instanceof Array) {
 
-        var lines = message.split('\n');
-        var numLines = lines.length;
         var messageExpanded = '';
 
         // repeat -m as needed
-        for (var i = 0; i < numLines; i++) {
-          messageExpanded += messageEntry(lines[i]);
+        for (var i = 0; i < message.length; i++) {
+          messageExpanded += messageEntry(message[i]);
         }
         cmd += messageExpanded + opt.args; 
         if(!opt.disableAppendPaths) {
           cmd += ' ' + escape(paths); 
         }
       } else {
-        cmd += message + opt.args;
+        cmd += '-m "' + message + '" ' + opt.args;
         if(!opt.disableAppendPaths) {
           cmd += ' ' + escape(paths); 
         }

--- a/test/commit.js
+++ b/test/commit.js
@@ -73,4 +73,25 @@ module.exports = function(git, util){
         gitS.end();
     });
   });
+
+  it('should commit a file to the repo when passing multiple messages', function(done) {
+    var fakeFile = util.testOptionsFiles[5];
+    exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
+      function (error, stdout, stderr) {
+        var opt = {cwd: './test/repo/', disableAppendPaths: true};
+        var gitS = git.commit(['initial commit', 'additional message'], opt);
+        gitS.on('end', function(err) {
+          if(err) {console.error(err); }
+          setTimeout(function(){
+            var result = fs.readFileSync(util.testCommit)
+              .toString('utf8');
+            result.should.match(/initial commit/);
+            result.should.match(/additional message/);
+            done();
+          }, 100);
+        });
+        gitS.write(fakeFile);
+        gitS.end();
+    });
+  });
 };


### PR DESCRIPTION
Multiple lines should happen by passing an array of messages as message
instead of relying upon finding newline characters. A given message can
have newline characters without spawning a new -m argument. This fixes
this functionality.