### PR TITLE
Remove remote

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,8 +101,16 @@ gulp.task('commit', function(){
 // Run git remote add
 // remote is the remote repo
 // repo is the https url of the repo
-gulp.task('remote', function(){
+gulp.task('addremote', function(){
   git.addRemote('origin', 'https://github.com/stevelacy/git-test', function (err) {
+    if (err) throw err;
+  });
+});
+
+// Run git remote remove
+// remote is the remote repo
+gulp.task('removeremote', function(){
+  git.removeRemote('origin', function (err) {
     if (err) throw err;
   });
 });
@@ -315,6 +323,23 @@ Adds remote repo url
 
 ```js
 git.addRemote('origin', 'git-repo-url', function (err) {
+  //if (err) ...
+});
+```
+
+### git.removeRemote(remote, opt, cb)
+`git remote remove <remote>`
+
+Removes remote repo url
+
+`remote`: String, name of remote
+
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
+
+`cb`: function, passed err if any
+
+```js
+git.removeRemote('origin', function (err) {
   //if (err) ...
 });
 ```

--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ git.addRemote('origin', 'git-repo-url', function (err) {
 ### git.removeRemote(remote, opt, cb)
 `git remote remove <remote>`
 
-Removes remote repo url
+Removes remote repo
 
 `remote`: String, name of remote
 

--- a/lib/removeRemote.js
+++ b/lib/removeRemote.js
@@ -1,0 +1,25 @@
+'use strict';
+
+var gutil = require('gulp-util');
+var exec = require('child_process').exec;
+var escape = require('any-shell-escape');
+
+module.exports = function (remote, opt, cb) {
+  if (!cb && typeof opt === 'function') {
+    // optional options
+    cb = opt;
+    opt = {};
+  }
+  if (!cb || typeof cb !== 'function') cb = function () {};
+  if (!remote) cb(new Error('gulp-git: remote is required git.removeRemote("origin")'));
+  if (!opt) opt = {};
+  if (!opt.cwd) opt.cwd = process.cwd();
+  if (!opt.args) opt.args = ' ';
+
+  var cmd = 'git remote remove ' + opt.args + ' ' + escape([remote]);
+  return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
+    if (err) cb(err);
+    if (!opt.quiet) gutil.log(stdout, stderr);
+    cb();
+  });
+};

--- a/test/removeRemote.js
+++ b/test/removeRemote.js
@@ -1,0 +1,22 @@
+'use strict';
+
+var fs = require('fs');
+var path = require('path');
+var rimraf = require('rimraf');
+var should = require('should');
+var gutil = require('gulp-util');
+
+module.exports = function(git, util){
+
+  it('should remove the Remote origin from the git repo', function(done) {
+    var opt = {cwd: './test/repo/'};
+    git.removeRemote('origin', opt, function(){
+      should.exist('./test/repo/.git/');
+      fs.readFileSync('./test/repo/.git/config')
+        .toString('utf8')
+        .should.not.match(/https:\/\/github.com\/stevelacy\/git-test/);
+      done();
+    });
+  });
+
+};


### PR DESCRIPTION
Hi Steve
I'm trying to use git-gulp to create a gulp script to deploy a website by pushing a git repo to the web server.
It would really help if I could have removeRemote functionality to compliment addRemote
I've updated the readme and added a test. 

Thanks
