### PR TITLE
add option to listen to commit progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ gulp.task('commit', function(){
     .pipe(git.commit(['initial commit', 'additional message']));
 });
 
+// Run git commit, emiting 'data' event during progress
+// This is useful when you have long running githooks
+// and want to show progress to your users on screen
+gulp.task('commit', function(){
+  return gulp.src('./git-test/*')
+    .pipe(git.commit('initial commit', {emitData:true}))
+    .on('data',function(data) {
+      console.log(data);
+    });
+});
+
 // Run git remote add
 // remote is the remote repo
 // repo is the https url of the repo

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -65,13 +65,25 @@ module.exports = function(message, opt) {
       cmd += '-a ' + opt.args + (opt.args.indexOf('--no-edit') === -1 ? ' --no-edit' : '');
     }
     var self = this;
-    exec(cmd, {cwd: opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr){
+    var execChildProcess = exec(cmd, {cwd: opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr){
       if (err) return cb(err);
       if (!opt.quiet) gutil.log(stdout, stderr);
       files.forEach(self.push.bind(self));
       self.emit('end');
       return cb();
     });
+    
+    // If the user wants, we'll emit data events during exec
+    // they can listen to them with .on('data',function(data){ });
+    // in their task
+    if(opt.emitData) {
+      execChildProcess.stdout.on('data',function(data){
+        self.emit('data', data);
+      });
+      execChildProcess.stderr.on('data',function(data){
+        self.emit('data', data);
+      }); 
+    }
   };
 
   return through.obj(write, flush);

--- a/test/commit.js
+++ b/test/commit.js
@@ -94,4 +94,46 @@ module.exports = function(git, util){
         gitS.end();
     });
   });
+  
+  it('should not fire a data event by default', function(done) {
+    var fakeFile = util.testOptionsFiles[9];
+    exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
+      function (error, stdout, stderr) {
+        var opt = {cwd: './test/repo/'};
+        var gitS = git.commit('initial commit', opt);
+        var gotData = false;
+        var wasDone = false;
+        
+        gitS.on('data', function(data) {
+          gotData = true; 
+        });
+        
+        gitS.on('end', function() {
+          gotData.should.be.false;
+          if(!wasDone) {
+            done();
+            wasDone=true;
+          }
+        });
+        
+        gitS.write(fakeFile);
+        gitS.end();
+    });
+  });
+    
+  it('should fire a data event if emitData is true', function(done) {
+    var fakeFile = util.testOptionsFiles[4];
+    exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
+      function (error, stdout, stderr) {
+        var opt = {cwd: './test/repo/', emitData: true};
+        var gitS = git.commit('initial commit', opt);
+        gitS.on('data', function(data) {
+          if (data) { 
+            done();
+          }
+        });
+        gitS.write(fakeFile);
+        gitS.end();
+    });
+  });
 };


### PR DESCRIPTION
Closes #98
Adds tests, readme and code that allows for watching data events during git commit.