### PR TITLE
Allow `null` as branch name when pushing, use `tag()` method as getter

### DIFF
--- a/README.md
+++ b/README.md
@@ -419,7 +419,7 @@ Pushes changes to remote repo
 
 `remote`: String, name of remote, default: `origin`
 
-`branch`: String, branch, default: `master`
+`branch`: String (may be `null`), branch, default: `master`
 
 `opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 

--- a/README.md
+++ b/README.md
@@ -434,11 +434,11 @@ git.push('origin', 'master', function (err) {
 ### git.tag(version, message, opt, cb)
 `git tag -a/s <version> -m <message>`
 
-Tags repo with release version
+Tags repo with release version, returns all tags when used without arguments
 
-`version`: String, tag name
+`version`: String (optional), tag name
 
-`message`: String, tag message
+`message`: String (optional), tag message
 
 `opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true}`
 

--- a/lib/push.js
+++ b/lib/push.js
@@ -7,7 +7,11 @@ var escape = require('any-shell-escape');
 module.exports = function (remote, branch, opt, cb) {
 
   if (!remote) remote = 'origin';
-  if (!branch) branch = 'master';
+  if (branch === null) {
+    branch = '';
+  } else if (!branch) {
+    branch = 'master';
+  }
   if (!cb && typeof opt === 'function') {
     cb = opt;
     opt = {};

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -10,20 +10,30 @@ module.exports = function (version, message, opt, cb) {
     cb = opt;
     opt = {};
   }
+  if (!cb && typeof version === 'function') {
+    cb = version;
+    version = '';
+    message = '';
+  }
   if (!cb || typeof cb !== 'function') cb = function () {};
-  if (!version) return cb(new Error('Version must be defined'));
-  if (!message) return cb(new Error('Message must be defined'));
+  if (!message && version) return cb(new Error('Message must be defined'));
   if (!opt) opt = {};
   if (!opt.cwd) opt.cwd = process.cwd();
   if (!opt.args) opt.args = ' ';
 
   var signedarg = opt.signed ? ' -s ' : ' -a ';
 
-  var cmd = 'git tag ' + signedarg + ' -m "' + message + '" ' + opt.args + ' ' + escape([version]);
+  var cmd = 'git tag';
+  if (version !== '') {
+    cmd += ' ' + signedarg + ' -m "' + message + '" ' + opt.args + ' ' + escape([version]);
+  }
   var templ = gutil.template(cmd, {file:message});
   return exec(templ, {cwd: opt.cwd}, function(err, stdout, stderr){
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
-    cb();
+    if (!opt.quiet && version !== '') gutil.log(stdout, stderr);
+    if (version === '') {
+      stdout = stdout.split('\n');
+    }
+    cb(stdout);
   });
 };


### PR DESCRIPTION
This pull request addresses the following issues:
- allow to push tags directly to a repository;
- let the `tag()` method function as getter to obtain a list of all tags.