### PR TITLE
git commit changes

### DIFF
--- a/lib/commit.js
+++ b/lib/commit.js
@@ -66,7 +66,7 @@ module.exports = function(message, opt) {
     }
     var self = this;
     var execChildProcess = exec(cmd, opt, function(err, stdout, stderr) {
-      if (err) return cb(err);
+      if (err && (stdout && stdout.toString().indexOf('no changes added to commit') === 0)) return cb(err);
       if (!opt.quiet) gutil.log(stdout, stderr);
       files.forEach(self.push.bind(self));
       self.emit('end');

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -25,7 +25,7 @@ module.exports = function(message, opt) {
 
   var write = function(file, enc, cb){
     files.push(file);
-    paths.push(path.relative(opt.cwd, file.path).replace('\\','/'));
+    paths.push(path.relative(opt.cwd, file.path));
     cb();
   };
 


### PR DESCRIPTION
Hi,

I noticed that replacing \ with / breaks files paths - I am receiving errors. Additionally if someone would like to use gulp-git in sequence and there is nothing to commit it will break gulp task, that is why I added custom handling of git message 'no changes added to commit'.

Regards,
Adam
