### PR TITLE
Pass tag output to callback

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -34,6 +34,6 @@ module.exports = function (version, message, opt, cb) {
     if (version === '') {
       stdout = stdout.split('\n');
     }
-    return cb();
+    return cb(null, stdout);
   });
 };


### PR DESCRIPTION
The output from `git.tag` with no arguments wasn't being passed to the callback function.