### PR TITLE
Allow multiple refspecs on fetch, pull and push

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,11 +143,25 @@ gulp.task('push', function(){
   });
 });
 
+// Run git push with multiple branches and tags
+gulp.task('push', function(){
+  git.push('origin', ['master', 'develop'], {args: " --tags"}, function (err) {
+    if (err) throw err;
+  });
+});
+
 // Run git pull
 // remote is the remote repo
 // branch is the remote branch to pull from
 gulp.task('pull', function(){
   git.pull('origin', 'master', {args: '--rebase'}, function (err) {
+    if (err) throw err;
+  });
+});
+
+// Run git pull from multiple branches
+gulp.task('pull', function(){
+  git.pull('origin', ['master', 'develop'], function (err) {
     if (err) throw err;
   });
 });

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -22,7 +22,7 @@ module.exports = function (remote, branch, opt, cb) {
   if(remote)
     args.push(remote);
   if(branch)
-    args.push(branch);
+    args = args.concat(branch);
   if(args.length > 0)
     cmd += escape(args);
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -17,7 +17,7 @@ module.exports = function (remote, branch, opt, cb) {
   if (!opt.cwd) opt.cwd = process.cwd();
   if (!opt.args) opt.args = ' ';
 
-  var cmd = 'git pull ' + opt.args + ' ' + escape([remote, branch]);
+  var cmd = 'git pull ' + opt.args + ' ' + escape([].concat(remote, branch));
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if (err) return cb(err);
     if (!opt.quiet) gutil.log(stdout, stderr);

--- a/lib/push.js
+++ b/lib/push.js
@@ -21,7 +21,7 @@ module.exports = function (remote, branch, opt, cb) {
   if (!opt.cwd) opt.cwd = process.cwd();
   if (!opt.args) opt.args = ' ';
 
-  var cmd = 'git push ' + escape([remote, branch]) + ' ' + opt.args;
+  var cmd = 'git push ' + escape([].concat(remote, branch)) + ' ' + opt.args;
   return exec(cmd, {cwd: opt.cwd}, function(err, stdout, stderr){
     if (err) return cb(err);
     if (!opt.quiet) gutil.log(stdout, stderr);


### PR DESCRIPTION
Enables users to specify `branch` parameter as an _array_ of strings in _pull_, _push_ and _fetch_ `git` commands.

Example:

```javascript
git.push('origin', ['develop', 'master'], { quiet: true, args: '--tags' }, done);
```

Generates the following valid shell command:

```sh
$ git push origin develop master --tags
```