### PR TITLE
Add newline support for commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,7 +330,7 @@ Commits changes to repo
 
 `message`: String, commit message
 
-`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', maxBuffer: 200 * 1024, quiet: true, disableMessageRequirement: false, disableAppendPaths: false}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', maxBuffer: 200 * 1024, quiet: true, disableMessageRequirement: false, disableAppendPaths: false, multiline: false}`
 
 ```js
 gulp.src('./*')

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -46,6 +46,18 @@ gulp.task('commitmulti', function(){
   .pipe(git.commit(['initial commit', 'additional message']));
 });
 
+// Commit files using the multiline option
+gulp.task('commitmultiline', function(){
+  gulp.src('./*')
+  .pipe(git.commit(['initial commit', 'additional message'], { mutiline: true }));
+});
+
+// Commit files with multiline messages
+gulp.task('commitmultiline', function(){
+  gulp.src('./*')
+  .pipe(git.commit('initial commit\nadditional message'));
+});
+
 // Clone remote repo to current directory ($CWD/git-test)
 gulp.task('clone', function() {
   git.clone('https://github.com/stevelacy/git-test', function(err) {

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -42,7 +42,7 @@ module.exports = function(message, opt) {
       // Check if the message is multiline
       if (message && message instanceof Array) {
 
-        if (opt.multi) {
+        if (opt.multiline) {
           writeStdin = true;
           message = message.join('\n');
         } else {
@@ -76,7 +76,7 @@ module.exports = function(message, opt) {
     }
     var self = this;
 
-    // If `message` was an array and `opt.multi` was true
+    // If `message` was an array and `opt.multiline` was true
     // or was a string containing newlines, we append '-F -'
     if (writeStdin) {
       cmd += ' -F -';

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -34,6 +34,7 @@ module.exports = function(message, opt) {
   };
 
   var flush = function(cb){
+    var writeStdin = false;
     var cmd = 'git commit ';
 
     if (message && opt.args.indexOf('--amend') === -1) {
@@ -41,18 +42,27 @@ module.exports = function(message, opt) {
       // Check if the message is multiline
       if (message && message instanceof Array) {
 
-        var messageExpanded = '';
+        if (opt.multi) {
+          writeStdin = true;
+          message = message.join('\n');
+        } else {
+          var messageExpanded = '';
 
-        // repeat -m as needed
-        for (var i = 0; i < message.length; i++) {
-          messageExpanded += messageEntry(message[i]);
+          // repeat -m as needed
+          for (var i = 0; i < message.length; i++) {
+            messageExpanded += messageEntry(message[i]);
+          }
+          cmd += messageExpanded + opt.args;
         }
-        cmd += messageExpanded + opt.args;
         if(!opt.disableAppendPaths) {
           cmd += ' ' + escape(paths);
         }
       } else {
-        cmd += '-m "' + message + '" ' + opt.args;
+        if (~message.indexOf('\n')) {
+          writeStdin = true;
+        } else {
+          cmd += '-m "' + message + '" ' + opt.args;
+        }
         if(!opt.disableAppendPaths) {
           cmd += ' ' + escape(paths);
         }
@@ -65,6 +75,13 @@ module.exports = function(message, opt) {
       cmd += '-a ' + opt.args + (opt.args.indexOf('--no-edit') === -1 ? ' --no-edit' : '');
     }
     var self = this;
+
+    // If `message` was an array and `opt.multi` was true
+    // or was a string containing newlines, we append '-F -'
+    if (writeStdin) {
+      cmd += ' -F -';
+    }
+
     var execChildProcess = exec(cmd, opt, function(err, stdout, stderr) {
       if (err) return cb(err);
       if (!opt.quiet) gutil.log(stdout, stderr);
@@ -72,6 +89,11 @@ module.exports = function(message, opt) {
       self.emit('end');
       return cb();
     });
+
+    if (writeStdin) {
+      execChildProcess.stdin.write(message);
+      execChildProcess.stdin.end();
+    }
 
     // If the user wants, we'll emit data events during exec
     // they can listen to them with .on('data',function(data){ });

--- a/test/_util.js
+++ b/test/_util.js
@@ -36,7 +36,7 @@ var testFiles = (function(){
 
 var testOptionsFiles = (function(){
   var testFiles = [];
-  for (var i = 0; i < 10; i++) {
+  for (var i = 0; i < 12; i++) {
     testFiles[i] = {
       base: 'test/repo',
       cwd: 'test/repo',

--- a/test/commit.js
+++ b/test/commit.js
@@ -115,11 +115,11 @@ module.exports = function(git, util){
     });
   });
 
-  it('should commit a file to the repo when passing multiple messages and multi option', function(done) {
+  it('should commit a file to the repo when passing multiple messages and multiline option', function(done) {
     var fakeFile = util.testOptionsFiles[11];
     exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
       function (error, stdout, stderr) {
-        var opt = {cwd: './test/repo/', disableAppendPaths: true, multi: true};
+        var opt = {cwd: './test/repo/', disableAppendPaths: true, multiline: true};
         var gitS = git.commit(['initial commit', 'additional message'], opt);
         gitS.on('end', function(err) {
           if(err) {console.error(err); }

--- a/test/commit.js
+++ b/test/commit.js
@@ -94,6 +94,46 @@ module.exports = function(git, util){
         gitS.end();
     });
   });
+
+  it('should commit a file to the repo when passing a message with newlines', function(done) {
+    var fakeFile = util.testOptionsFiles[10];
+    exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
+      function (error, stdout, stderr) {
+        var opt = {cwd: './test/repo/', disableAppendPaths: true};
+        var gitS = git.commit('initial commit\nadditional message', opt);
+        gitS.on('end', function(err) {
+          if(err) {console.error(err); }
+          setTimeout(function(){
+            var result = fs.readFileSync(util.testCommit)
+              .toString('utf8');
+            result.should.match(/initial commit\nadditional message/);
+            done();
+          }, 300);
+        });
+        gitS.write(fakeFile);
+        gitS.end();
+    });
+  });
+
+  it('should commit a file to the repo when passing multiple messages and multi option', function(done) {
+    var fakeFile = util.testOptionsFiles[11];
+    exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
+      function (error, stdout, stderr) {
+        var opt = {cwd: './test/repo/', disableAppendPaths: true, multi: true};
+        var gitS = git.commit(['initial commit', 'additional message'], opt);
+        gitS.on('end', function(err) {
+          if(err) {console.error(err); }
+          setTimeout(function(){
+            var result = fs.readFileSync(util.testCommit)
+              .toString('utf8');
+            result.should.match(/initial commit\nadditional message/);
+            done();
+          }, 300);
+        });
+        gitS.write(fakeFile);
+        gitS.end();
+    });
+  });
   
   it('should not fire a data event by default', function(done) {
     var fakeFile = util.testOptionsFiles[9];


### PR DESCRIPTION
Adds support for newlines in commits, either by passing a message with newlines or an array of messages with the option `multi`.

Closes #122