### PR TITLE
Fix git tag message escaping

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -25,7 +25,8 @@ module.exports = function (version, message, opt, cb) {
 
   var cmd = 'git tag';
   if (version !== '') {
-    cmd += ' ' + signedarg + ' -m ' + escape([message]) + ' ' + opt.args + ' ' + escape([version]);
+    cmd += ' ' + signedarg + ' -m ' + escape([message]) + ' ';
+    cmd += opt.args + ' ' + escape([version]);
   }
   var templ = gutil.template(cmd, {file: message});
   return exec(templ, {cwd: opt.cwd}, function(err, stdout, stderr){

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -25,7 +25,7 @@ module.exports = function (version, message, opt, cb) {
 
   var cmd = 'git tag';
   if (version !== '') {
-    cmd += ' ' + signedarg + ' -m "' + message + '" ' + opt.args + ' ' + escape([version]);
+    cmd += ' ' + signedarg + ' -m ' + escape([message]) + ' ' + opt.args + ' ' + escape([version]);
   }
   var templ = gutil.template(cmd, {file: message});
   return exec(templ, {cwd: opt.cwd}, function(err, stdout, stderr){


### PR DESCRIPTION
This change properly escapes the tag message (`message`) just like the tag name (`version`) is escaped. Without the change, the double quotes in `'"message" test'` are not kept and other problems could occur.