### PR TITLE
Git tag allow empty message

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,6 +203,13 @@ gulp.task('tag', function(){
   });
 });
 
+// Tag the repo with a version and empty message
+gulp.task('tag', function(){
+  git.tag('v1.1.1', '', function (err) {
+    if (err) throw err;
+  });
+});
+
 // Tag the repo With signed key
 gulp.task('tagsec', function(){
   git.tag('v1.1.1', 'Version message with signed key', {signed: true}, function (err) {

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -16,7 +16,7 @@ module.exports = function (version, message, opt, cb) {
     message = '';
   }
   if (!cb || typeof cb !== 'function') cb = function () {};
-  if (!message && version) return cb(new Error('Message must be defined'));
+  if (!message) message = '\'\''; else message = escape([message]);
   if (!opt) opt = {};
   if (!opt.cwd) opt.cwd = process.cwd();
   if (!opt.args) opt.args = ' ';
@@ -25,7 +25,7 @@ module.exports = function (version, message, opt, cb) {
 
   var cmd = 'git tag';
   if (version !== '') {
-    cmd += ' ' + signedarg + ' -m ' + escape([message]) + ' ';
+    cmd += ' ' + signedarg + ' -m ' + message + ' ';
     cmd += opt.args + ' ' + escape([version]);
   }
   var templ = gutil.template(cmd, {file: message});


### PR DESCRIPTION
It is common to create an annotated tag with an empty message as so:
`$ git tag -a -m '' 'v1.2.3'`
This change does not break other functionality and adds an example in the README file.