### PR TITLE
Fix file existence tests

### DIFF
--- a/test/add.js
+++ b/test/add.js
@@ -13,8 +13,10 @@ module.exports = function(git, util){
     var gitS = git.add();
     gitS.on('data', function(newFile){
       should.exist(newFile);
-      should.exist('test/.git/objects/');
-      done();
+      fs.stat('test/repo/.git/objects/', function(err, stats){
+        should.not.exist(err);
+        done();
+      });
     });
     gitS.write(fakeFile);
     gitS.end();
@@ -28,7 +30,9 @@ module.exports = function(git, util){
     var gitS = git.add();
     gitS.on('data', function(newFile){
       should.exist(newFile);
-      should.exist('test/.git/objects/');
+      fs.stat('test/repo/.git/objects/', function(err, stats){
+        should.not.exist(err);
+      });
     });
     fakeFiles.forEach(function(file){
       gitS.write(file);

--- a/test/addRemote.js
+++ b/test/addRemote.js
@@ -12,7 +12,7 @@ module.exports = function(git, util){
     var opt = {cwd: './test/repo/'};
     var origin = 'https://github.com/stevelacy/git-test';
     git.addRemote('origin', origin, opt, function(){
-      should.exist('./test/repo/.git/');
+      fs.statSync('./test/repo/.git/');
       fs.readFileSync('./test/repo/.git/config')
         .toString('utf8')
         .should.match(/https:\/\/github.com\/stevelacy\/git-test/);

--- a/test/branch.js
+++ b/test/branch.js
@@ -11,21 +11,25 @@ module.exports = function(git, util){
   it('should create a new branch', function(done){
     var opt = {cwd: './test/repo/'};
     git.branch('testBranch', opt, function(){
-      should.exist('test/repo/.git/refs/heads/testBranch');
-      done();
+      fs.stat('test/repo/.git/refs/heads/testBranch', function(err, stats) {
+        should.not.exist(err);
+        done();
+      });
     });
   });
 
   it('should create new branch, checkout and return its name', function(done){
     var opt = {cwd: './test/repo/'};
     git.branch('anotherBranch', opt, function(){
-      should.exist('test/repo/.git/refs/heads/anotherBranch');
-      git.checkout('anotherBranch', opt, function(){
-        opt = {args: '--abbrev-ref HEAD', cwd: opt.cwd};
-        git.revParse(opt, function (err, branch) {
-          branch.should.equal('anotherBranch');
-          should.not.exist(err);
-          done();
+      fs.stat('test/repo/.git/refs/heads/anotherBranch', function(err, stats) {
+        should.not.exist(err);
+        git.checkout('anotherBranch', opt, function(){
+          opt = {args: '--abbrev-ref HEAD', cwd: opt.cwd};
+          git.revParse(opt, function (err, branch) {
+            branch.should.equal('anotherBranch');
+            should.not.exist(err);
+            done();
+          });
         });
       });
     });

--- a/test/clone.js
+++ b/test/clone.js
@@ -13,8 +13,11 @@ module.exports = function(git, util){
     git.clone(repo, {args: './test/tmp'}, done);
   });
 
-  it('should have cloned project into tmp directory', function(){
-    should.exist('./test/tmp/.git');
+  it('should have cloned project into tmp directory', function(done){
+    fs.stat('./test/tmp/.git', function(err, stats){
+      should.not.exist(err);
+      done();
+    });
   });
 
   afterEach(function(done){

--- a/test/init.js
+++ b/test/init.js
@@ -13,8 +13,10 @@ module.exports = function(git, testFiles, testCommit){
   });
 
   it('should initialize a empty git repo', function(done) {
-    should.exist('test/repo/.git/');
-    done();
+    fs.stat('test/repo/.git/', function(err, stats) {
+      should.not.exist(err);
+      done();
+    });
   });
 
 };

--- a/test/removeRemote.js
+++ b/test/removeRemote.js
@@ -11,11 +11,13 @@ module.exports = function(git, util){
   it('should remove the Remote origin from the git repo', function(done) {
     var opt = {cwd: './test/repo/'};
     git.removeRemote('origin', opt, function(){
-      should.exist('./test/repo/.git/');
-      fs.readFileSync('./test/repo/.git/config')
-        .toString('utf8')
-        .should.not.match(/https:\/\/github.com\/stevelacy\/git-test/);
-      done();
+      fs.stat('./test/repo/.git/', function(err, stats){
+        should.not.exist(err);
+        fs.readFileSync('./test/repo/.git/config')
+          .toString('utf8')
+          .should.not.match(/https:\/\/github.com\/stevelacy\/git-test/);
+        done();
+      });
     });
   });
 

--- a/test/submodule.js
+++ b/test/submodule.js
@@ -18,9 +18,10 @@ module.exports = function(git, testFiles, testCommit){
       fs.readFileSync('test/repo/.gitmodules')
         .toString('utf8')
         .should.match(new RegExp(url.replace(/[\/]/g, '\\$&')));
-      should.exist('test/repo/testSubmodule');
-      should.exist('test/repo/testSubmodule/.git/');
-      done();
+      fs.stat('test/repo/testSubmodule/.git', function(err, stats){
+        should.not.exist(err);
+        done();
+      });
     });
   });
 
@@ -28,14 +29,15 @@ module.exports = function(git, testFiles, testCommit){
     var args = {cwd: 'test/repo'};
 
     git.updateSubmodule(args, function(){
-      should.exist('test/repo/testSubmodule');
-      should.exist('test/repo/testSubmodule/.git/');
-      done();
+      fs.stat('test/repo/testSubmodule/.git', function(err, stats){
+        should.not.exist(err);
+        done();
+      });
     });
   });
 
   after(function(done){
-    rimraf('test/testSubmodule', function(err){
+    rimraf('test/repo/testSubmodule', function(err){
       if(err) return done(err);
       done();
     });

--- a/test/tag.js
+++ b/test/tag.js
@@ -12,14 +12,14 @@ module.exports = function(git, testFiles, testCommit){
   // no pull delay, and has git configured.
 
   it('should tag a version of the repo', function(done) {
-    git.tag('v1.2.3', 'message', {cwd: './test/'}, function() {
-      should.exist('test/.git/refs/tags/v1.2.3');
+    git.tag('v1.2.3', 'message', {cwd: './test/repo/'}, function() {
+      should.exist('test/repo/.git/refs/tags/v1.2.3');
       done();
     });
   });
 
   it('should not throw an error on success', function(done) {
-    git.tag('v2', 'message', {cwd: './test/'}, function(err) {
+    git.tag('v2', 'message', {cwd: './test/repo/'}, function(err) {
       should.not.exist(err);
       done();
     });

--- a/test/tag.js
+++ b/test/tag.js
@@ -13,8 +13,10 @@ module.exports = function(git, testFiles, testCommit){
 
   it('should tag a version of the repo', function(done) {
     git.tag('v1.2.3', 'message', {cwd: './test/repo/'}, function() {
-      should.exist('test/repo/.git/refs/tags/v1.2.3');
-      done();
+      fs.stat('test/repo/.git/refs/tags/v1.2.3', function(err, stats) {
+        should.not.exist(err);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
This pull request fixes #132. [`fs.stat(path, callback)`](https://nodejs.org/api/fs.html#fs_fs_stat_path_callback) is used to test if file or directory exists.

Also, some tests used `'test/'` directory as cwd instead of the `'test/repo/'` directory. This would cause some tests to modify the projects main `.git/` directory. This is also fixed in this PR.