### PR TITLE
Fix commit test error

### DIFF
--- a/test/commit.js
+++ b/test/commit.js
@@ -134,7 +134,7 @@ module.exports = function(git, util){
         gitS.end();
     });
   });
-  
+
   it('should not fire a data event by default', function(done) {
     var fakeFile = util.testOptionsFiles[9];
     exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
@@ -143,11 +143,11 @@ module.exports = function(git, util){
         var gitS = git.commit('initial commit', opt);
         var gotData = false;
         var wasDone = false;
-        
+
         gitS.on('data', function(data) {
-          gotData = true; 
+          gotData = true;
         });
-        
+
         gitS.on('end', function() {
           gotData.should.be.false;
           if(!wasDone) {
@@ -155,12 +155,12 @@ module.exports = function(git, util){
             wasDone=true;
           }
         });
-        
+
         gitS.write(fakeFile);
         gitS.end();
     });
   });
-    
+
   it('should fire a data event if emitData is true', function(done) {
     var fakeFile = util.testOptionsFiles[4];
     exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
@@ -168,7 +168,7 @@ module.exports = function(git, util){
         var opt = {cwd: './test/repo/', emitData: true};
         var gitS = git.commit('initial commit', opt);
         gitS.on('data', function(data) {
-          if (data) { 
+          if (data) {
             done();
           }
         });

--- a/test/commit.js
+++ b/test/commit.js
@@ -162,12 +162,12 @@ module.exports = function(git, util){
   });
 
   it('should fire a data event if emitData is true', function(done) {
-    var fakeFile = util.testOptionsFiles[4];
+    var fakeFile = util.testOptionsFiles[6];
     exec('git add ' + fakeFile.path, {cwd: './test/repo/'},
       function (error, stdout, stderr) {
         var opt = {cwd: './test/repo/', emitData: true};
         var gitS = git.commit('initial commit', opt);
-        gitS.on('data', function(data) {
+        gitS.once('data', function(data) {
           if (data) {
             done();
           }


### PR DESCRIPTION
There is an intermittent error in the tests you can see [here](https://travis-ci.org/stevelacy/gulp-git/jobs/147330352#L265). It is caused by a file in a commit test (`util.testOptionsFiles[4]`) to be added and committed. Since the same file is added and committed in a test above, the commit fails.

Also, the `data` event is now called twice and causes `done()` to be executed twice therefore `gitS.once` is used instead of `gitS.on`.

Some trailing whitespaces were also removed from the file.