### PR TITLE
support git branch --contains

### DIFF
--- a/lib/branch.js
+++ b/lib/branch.js
@@ -25,6 +25,6 @@ module.exports = function (branch, opt, cb) {
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
     if (!opt.quiet) gutil.log(stdout, stderr);
-    cb();
+    cb(null, stdout);
   });
 };


### PR DESCRIPTION
`git branch --contains` returns through stdout, this is the result of the operation.