### PR TITLE
Add git.add({ cwd: '/cwd/path' }) option to ReadMe

### DIFF
--- a/README.md
+++ b/README.md
@@ -352,7 +352,7 @@ git.clone('https://remote.git', {args: './sub/folder'}, function (err) {
 
 Adds files to repo
 
-`opt`: Object (optional) `{args: 'options', quiet: true, maxBuffer: 200 * 1024}`
+`opt`: Object (optional) `{args: 'options', cwd: '/cwd/path', quiet: true, maxBuffer: 200 * 1024}`
 
 ```js
 gulp.src('./*')


### PR DESCRIPTION
I could not find this option in the docs but it seems to be working.