### PR TITLE
core: remove deprecated gulp-util dependency

### DIFF
--- a/lib/add.js
+++ b/lib/add.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -29,7 +29,7 @@ module.exports = function (opt) {
 
     exec(cmd, {cwd: cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
       if (err) cb(err);
-      if (!opt.quiet) gutil.log(stdout, stderr);
+      if (!opt.quiet) log(stdout, stderr);
       files.forEach(that.push.bind(that));
       that.emit('end');
       cb();

--- a/lib/addRemote.js
+++ b/lib/addRemote.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -22,7 +22,7 @@ module.exports = function (remote, url, opt, cb) {
   var cmd = 'git remote add ' + opt.args + ' ' + escape([remote, url]);
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 };

--- a/lib/addSubmodule.js
+++ b/lib/addSubmodule.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 module.exports = function (url, name, opt, cb) {
@@ -16,7 +16,7 @@ module.exports = function (url, name, opt, cb) {
   var cmd = 'git submodule add ' + opt.args + ' ' + url + ' ' + name;
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err && cb) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     if (cb) cb();
   });
 };

--- a/lib/branch.js
+++ b/lib/branch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -24,7 +24,7 @@ module.exports = function (branch, opt, cb) {
   var cmd = 'git branch ' + opt.args + ' ' + escape([branch]);
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb(null, stdout);
   });
 };

--- a/lib/catFile.js
+++ b/lib/catFile.js
@@ -5,7 +5,7 @@
  */
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var PluginError = require('plugin-error');
 var spawn = require('child_process').spawn;
 var stripBom = require('strip-bom-stream');
 
@@ -91,7 +91,7 @@ module.exports = function (opt) {
     var that = this;
 
     readStream(catFile.stderr, function(error) {
-      that.emit('error', new gutil.PluginError('gulp-git', 'Command failed: ' + catFile.spawnargs.join(' ').trim() + '\n' + error.toString()));
+      that.emit('error', new PluginError('gulp-git', 'Command failed: ' + catFile.spawnargs.join(' ').trim() + '\n' + error.toString()));
     });
 
     if (opt.stripBOM) {

--- a/lib/checkout.js
+++ b/lib/checkout.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -21,7 +21,7 @@ module.exports = function (branch, opt, cb) {
   var cmd = 'git checkout ' + opt.args + ' ' + escape([branch]);
   exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb(null);
   });
 };

--- a/lib/checkoutFiles.js
+++ b/lib/checkoutFiles.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -18,7 +18,7 @@ module.exports = function (opt) {
 
     exec(cmd, {cwd: file.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
       if (err) return cb(err);
-      if (!opt.quiet) gutil.log(stdout, stderr);
+      if (!opt.quiet) log(stdout, stderr);
       that.push(file);
       cb(null);
     });

--- a/lib/clean.js
+++ b/lib/clean.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -34,7 +34,7 @@ module.exports = function (paths, opt, cb) {
     if (err)
       return cb(err);
     if (!opt.quiet)
-      gutil.log(stdout, stderr);
+      log(stdout, stderr);
     cb();
   });
 };

--- a/lib/clone.js
+++ b/lib/clone.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -20,7 +20,7 @@ module.exports = function (remote, opt, cb) {
   var cmd = 'git clone ' + escape([remote]) + ' ' + opt.args;
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 };

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 var path = require('path');
@@ -84,7 +84,7 @@ module.exports = function(message, opt) {
 
     var execChildProcess = exec(cmd, opt, function(err, stdout, stderr) {
       if (err && (String(stdout).indexOf('no changes added to commit') === 0)) return cb(err);
-      if (!opt.quiet) gutil.log(stdout, stderr);
+      if (!opt.quiet) log(stdout, stderr);
       files.forEach(self.push.bind(self));
       self.emit('end');
       return cb();

--- a/lib/diff.js
+++ b/lib/diff.js
@@ -6,7 +6,7 @@
 
 var Vinyl = require('vinyl');
 var through = require('through2');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var path = require('path');
 var exec = require('child_process').exec;
 var catFile = require('./catFile');
@@ -88,7 +88,7 @@ module.exports = function (compare, opt) {
     var files = getReaslt(stdout);
 
     if (opt.log) {
-      gutil.log('git diff --name-status ' + cmd + '\n' + files.map(function(diff) {
+      log('git diff --name-status ' + cmd + '\n' + files.map(function(diff) {
         return diff.status + '\t' + diff.dstPath;
       }).join('\n'));
     }

--- a/lib/exec.js
+++ b/lib/exec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 module.exports = function (opt, cb) {
@@ -20,9 +20,9 @@ module.exports = function (opt, cb) {
   var cmd = 'git ' + opt.args;
   return exec(cmd, {cwd : opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err, stderr);
-    if (opt.log && !opt.quiet) gutil.log(cmd + '\n' + stdout, stderr);
+    if (opt.log && !opt.quiet) log(cmd + '\n' + stdout, stderr);
     else {
-      if (!opt.quiet) gutil.log(cmd + ' (log : false)', stderr);
+      if (!opt.quiet) log(cmd + ' (log : false)', stderr);
     }
     cb(err, stdout);
   });

--- a/lib/fetch.js
+++ b/lib/fetch.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -29,7 +29,7 @@ module.exports = function (remote, branch, opt, cb) {
     cmd += escape(args);
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 };

--- a/lib/init.js
+++ b/lib/init.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 module.exports = function (opt, cb) {
@@ -19,7 +19,7 @@ module.exports = function (opt, cb) {
   var cmd = 'git init ' + opt.args;
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 

--- a/lib/merge.js
+++ b/lib/merge.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -21,7 +21,7 @@ module.exports = function (branch, opt, cb) {
   var cmd = 'git merge ' + opt.args + ' ' + escape([branch]);
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 };

--- a/lib/pull.js
+++ b/lib/pull.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -31,7 +31,7 @@ module.exports = function (remote, branch, opt, cb) {
 
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 };

--- a/lib/push.js
+++ b/lib/push.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 var revParse = require('./revParse');
@@ -49,7 +49,7 @@ module.exports = function (remote, branch, opt, cb) {
       maxBuffer: maxBuffer
     }, function(err, stdout, stderr) {
       if (err) return cb(err);
-      if (!opt.quiet) gutil.log(stdout, stderr);
+      if (!opt.quiet) log(stdout, stderr);
       cb();
     });
   }

--- a/lib/removeRemote.js
+++ b/lib/removeRemote.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -25,7 +25,7 @@ module.exports = function (remote, opt, cb) {
   var cmd = 'git remote remove ' + opt.args + ' ' + escape([remote]);
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 };

--- a/lib/reset.js
+++ b/lib/reset.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -21,7 +21,7 @@ module.exports = function (commit, opt, cb) {
   var cmd = 'git reset ' + opt.args + ' ' + escape([commit]);
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb();
   });
 

--- a/lib/revParse.js
+++ b/lib/revParse.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 /*
@@ -29,7 +29,7 @@ module.exports = function (opt, cb) {
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
     if (stdout) stdout = stdout.trim(); // Trim trailing cr-lf
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb(err, stdout); // return stdout to the user
   });
 };

--- a/lib/rm.js
+++ b/lib/rm.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var through = require('through2');
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -28,7 +28,7 @@ module.exports = function (opt) {
     var that = this;
     exec(cmd, {cwd: cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
       if (err) return cb(err);
-      if (!opt.quiet) gutil.log(stdout, stderr);
+      if (!opt.quiet) log(stdout, stderr);
       files.forEach(that.push.bind(that));
       cb();
     });

--- a/lib/stash.js
+++ b/lib/stash.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 module.exports = function(opt, cb) {
@@ -21,7 +21,7 @@ module.exports = function(opt, cb) {
   var cmd = 'git stash ' + opt.args;
   exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     cb(null);
   });
 

--- a/lib/status.js
+++ b/lib/status.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 module.exports = function (opt, cb) {
@@ -18,7 +18,7 @@ module.exports = function (opt, cb) {
   var cmd = 'git status ' + opt.args;
   return exec(cmd, {cwd : opt.cwd, maxBuffer: opt.maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err, stderr);
-    if (!opt.quiet) gutil.log(cmd + '\n' + stdout, stderr);
+    if (!opt.quiet) log(cmd + '\n' + stdout, stderr);
     if (cb) cb(err, stdout);
   });
 };

--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,6 +1,7 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
+var template = require('lodash.template');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -36,10 +37,10 @@ module.exports = function (version, message, opt, cb) {
     }
     cmd += opt.args + ' ' + escape([version]);
   }
-  var templ = gutil.template(cmd, {file: message});
+  var templ = template(cmd)({file: message});
   return exec(templ, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
-    if (!opt.quiet && version !== '') gutil.log(stdout, stderr);
+    if (!opt.quiet && version !== '') log(stdout, stderr);
     if (version === '') {
       stdout = stdout.split('\n');
     }

--- a/lib/updateSubmodule.js
+++ b/lib/updateSubmodule.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var gutil = require('gulp-util');
+var log = require('fancy-log');
 var exec = require('child_process').exec;
 
 module.exports = function(opt, cb) {
@@ -14,7 +14,7 @@ module.exports = function(opt, cb) {
   var cmd = 'git submodule update ' + opt.args;
   return exec(cmd, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err && cb) return cb(err);
-    if (!opt.quiet) gutil.log(stdout, stderr);
+    if (!opt.quiet) log(stdout, stderr);
     if (cb) cb();
   });
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
   "main": "./index.js",
   "dependencies": {
     "any-shell-escape": "^0.1.1",
-    "gulp-util": "^3.0.8",
+    "fancy-log": "^1.3.2",
+    "lodash.template": "^4.4.0",
+    "plugin-error": "^0.1.2",
     "require-dir": "^0.3.2",
     "strip-bom-stream": "^3.0.0",
     "through2": "^2.0.3",
@@ -20,6 +22,7 @@
   "devDependencies": {
     "eslint": "^3.17.0",
     "mocha": "^3.2.0",
+    "mock-require": "^2.0.2",
     "rimraf": "^2.6.1",
     "should": "^11.2.0"
   },

--- a/test/add.js
+++ b/test/add.js
@@ -2,12 +2,12 @@
 
 var fs = require('fs');
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 
 module.exports = function(git, util) {
 
   it('should add files to the git repo', function(done) {
-    var fakeFile = new gutil.File(util.testFiles[0]);
+    var fakeFile = new Vinyl(util.testFiles[0]);
     var gitS = git.add();
     gitS.on('data', function(newFile) {
       should.exist(newFile);
@@ -23,7 +23,7 @@ module.exports = function(git, util) {
   it('should add multiple files to the git repo', function(done) {
     var fakeFiles = [];
     util.testFiles.forEach(function(name) {
-      fakeFiles.push( new gutil.File(name) );
+      fakeFiles.push( new Vinyl(name) );
     });
     var gitS = git.add();
     gitS.on('data', function(newFile) {
@@ -39,7 +39,7 @@ module.exports = function(git, util) {
   });
 
   it('should fire an end event', function(done) {
-    var fakeFile = new gutil.File(util.testFiles[0]);
+    var fakeFile = new Vinyl(util.testFiles[0]);
     var gitS = git.add();
 
     gitS.on('end', function() {

--- a/test/main.js
+++ b/test/main.js
@@ -1,16 +1,15 @@
 'use strict';
 
+// omit logging
+var mock = require('mock-require');
+mock('fancy-log', function() {});
+
 var path = require('path');
 var rimraf = require('rimraf');
-var gutil = require('gulp-util');
 var git = require('../');
 
 // just so this file is clean
 var util = require('./_util');
-
-// omit logging
-gutil.log = function() {};
-
 
 describe('gulp-git', function() {
 

--- a/test/rm.js
+++ b/test/rm.js
@@ -1,13 +1,13 @@
 'use strict';
 
 var fs = require('fs');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 
 module.exports = function(git, util) {
 
   it('should rm a file', function(done) {
     var opt = {args: '-f', cwd: 'test/repo'};
-    var fakeFile = new gutil.File(util.testFiles[0]);
+    var fakeFile = new Vinyl(util.testFiles[0]);
     var gitS = git.rm(opt);
     gitS.once('data', function (newFile) {
       setTimeout(function() {
@@ -24,7 +24,7 @@ module.exports = function(git, util) {
   it('should rm multiple files', function(done) {
     var fakeFiles = [];
     util.testFiles.slice(1).forEach(function(file) {
-      fakeFiles.push(new gutil.File(file));
+      fakeFiles.push(new Vinyl(file));
     });
 
     var opt = {args: '-f', cwd: 'test/repo'};

--- a/test/status.js
+++ b/test/status.js
@@ -3,14 +3,14 @@
 var fs = require('fs');
 var path = require('path');
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 
 module.exports = function(git, util) {
 
   it('should git status --porcelain', function(done) {
 
     var opt = {args: '--porcelain', cwd: 'test/repo'};
-    var fakeFile = new gutil.File(util.testFiles[0]);
+    var fakeFile = new Vinyl(util.testFiles[0]);
     var fakeRelative = '?? ' + path.relative(util.repo, fakeFile.path);
     fs.openSync(fakeFile.path, 'w');
 


### PR DESCRIPTION
Hi,

Since `gulp-util` has been deprecated, this PR replace `gulp-util` with alternative individual modules. Please see: https://github.com/gulpjs/gulp-util