### PR TITLE
added the possibility to use a function as message in git.commit

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,15 @@ gulp.task('commit', function(){
     .pipe(git.commit('initial commit'));
 });
 
+// Run git commit with a computed commit message
+gulp.task('commit', function(){
+  let newVersion;
+  function computeNewVersion() { newVersion = /* ... */ }
+  return gulp.src('./git-test/*')
+    .pipe(computeNewVersion())
+    .pipe(git.commit(() => `Bumps to version ${newVersion}`));
+});
+
 // Run git commit with options
 gulp.task('commit', function(){
   return gulp.src('./git-test/*')

--- a/examples/gulpfile.js
+++ b/examples/gulpfile.js
@@ -25,6 +25,11 @@ gulp.task('commit', function() {
   .pipe(git.commit('initial commit'));
 });
 
+gulp.task('commitDelayed', function() {
+  gulp.src('./*')
+  .pipe(git.commit(function () { return 'commiting at exactly ' + new Date().toISOString(); }));
+});
+
 // Commit files with arguments
 gulp.task('commitopts', function() {
   gulp.src('./*')

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -11,7 +11,7 @@ var path = require('path');
 
 module.exports = function(message, opt) {
   if (!opt) opt = {};
-  if (!message || message.length === 0) {
+  if (!message || (message.length === 0 && typeof message !== 'function')) {
     if (opt.args.indexOf('--amend') === -1 && opt.disableMessageRequirement !== true) {
       throw new Error('gulp-git: Commit message is required git.commit("commit message") or --amend arg must be given');
     }
@@ -36,6 +36,10 @@ module.exports = function(message, opt) {
   var flush = function(cb) {
     var writeStdin = false;
     var cmd = 'git commit ';
+    // Allow delayed execution to determine the message
+    if (typeof message === 'function') {
+      message = message();
+    }
 
     if (message && opt.args.indexOf('--amend') === -1) {
 

--- a/lib/commit.js
+++ b/lib/commit.js
@@ -11,7 +11,7 @@ var path = require('path');
 
 module.exports = function(message, opt) {
   if (!opt) opt = {};
-  if (!message || (message.length === 0 && typeof message !== 'function')) {
+  if (!message) {
     if (opt.args.indexOf('--amend') === -1 && opt.disableMessageRequirement !== true) {
       throw new Error('gulp-git: Commit message is required git.commit("commit message") or --amend arg must be given');
     }

--- a/test/commit.js
+++ b/test/commit.js
@@ -197,4 +197,22 @@ module.exports = function(git, util) {
         gitS.end();
       });
   });
+
+  it('should allow functions for git message', function(done) {
+    var fakeFile = util.testFiles[0];
+    var opt = {cwd: './test/repo/'};
+    var msg = 'bogus commit message';
+    var gitS = git.commit(function() { return msg; }, opt);
+    msg = 'initial commit';
+    gitS.once('finish', function() {
+      setTimeout(function() {
+        fs.readFileSync(util.testCommit)
+          .toString('utf8')
+          .should.match(/initial commit/);
+        done();
+      }, 100);
+    });
+    gitS.write(fakeFile);
+    gitS.end();
+  });
 };


### PR DESCRIPTION
Hi there!

First off, great work on this plugin!

While setting up a new project and using gulp-bump, I wanted to achieve something like the following:

```javascript
return gulp.src([
    'package.json',
    'app/manifest.json'
  ], {
    base: './'
  })
    // bump the version number in those files
    .pipe(bump({
      type: importance
    }))
    // save it back to filesystem
    .pipe(gulp.dest('./'))
    // commit the changed version number
    .pipe(through.obj((file, enc, cb) => {
      const bumpData = file.bumpData;
      newVersion = bumpData.new;
    }))
    .pipe(git.commit(() => `[build] Version ${newVersion}`))
    // read only one file to get the version number
    .pipe(filter('package.json'))
    // **tag it in the repository**
    .pipe(tagVersion())
```

I wrestled with it for a while, trying to achieve it without code changes (i.e. with some kind of wrapper stream), but I'm not sure it'd be simple, given that you take the commit message in ahead of time, but accumulate state through each _transform call.  I'm new to gulp, so if there's another way to achieve this, let me know.