### PR TITLE
Update plugin-error@1.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "any-shell-escape": "^0.1.1",
     "fancy-log": "^1.3.2",
     "lodash.template": "^4.4.0",
-    "plugin-error": "^0.1.2",
+    "plugin-error": "^1.0.1",
     "require-dir": "^1.0.0",
     "strip-bom-stream": "^3.0.0",
     "through2": "^2.0.3",


### PR DESCRIPTION
Small update that can prune `plugin-error@0.1.2` in the dependencies 😅 Tests are passing. The update should be pretty safe https://github.com/gulpjs/plugin-error/releases

Really useful plugin by the way 💕