### PR TITLE
Removing lodash.template depency as per the component Governance Alert

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var log = require('fancy-log');
-var template = require('lodash.template');
+var _ = require('lodash');
 var exec = require('child_process').exec;
 var escape = require('any-shell-escape');
 
@@ -37,7 +37,7 @@ module.exports = function (version, message, opt, cb) {
     }
     cmd += opt.args + ' ' + escape([version]);
   }
-  var templ = template(cmd)({file: message});
+  var templ = _.template(cmd)({file: message});
   return exec(templ, {cwd: opt.cwd, maxBuffer: maxBuffer}, function(err, stdout, stderr) {
     if (err) return cb(err);
     if (!opt.quiet && version !== '') log(stdout, stderr);

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "dependencies": {
     "any-shell-escape": "^0.1.1",
     "fancy-log": "^1.3.2",
-    "lodash.template": "^4.4.0",
+    "lodash": "^4.17.21",
     "plugin-error": "^1.0.1",
     "require-dir": "^1.0.0",
     "strip-bom-stream": "^3.0.0",


### PR DESCRIPTION
As per the component governance alert made changes to remove lodash.template and replace with lodash. Made the fix as per the  suggestion provided in below link.

https://github.com/lodash/lodash/issues/5851

_"If you are using lodash.template directly in a project, to remove this alert you should install the latest version of lodash and use the template method off the main Lodash module instead, if you can't use another approach entirely."_